### PR TITLE
Update Drawing-with-Metapost.tex (sin -> \sin)

### DIFF
--- a/src/Drawing-with-Metapost.tex
+++ b/src/Drawing-with-Metapost.tex
@@ -6643,8 +6643,8 @@ two functions, by combining the \MP\ paths themselves.%
     draw tt withcolor 1/2[red, white];
     draw uu withcolor 1/4 green;
 
-    label.top("$f(x)=sin(x)$", point 290 of ss);
-    label.bot("$g(x)=\frac12 sin(3x)$", point 295 of tt); 
+    label.top("$f(x)=\sin(x)$", point 290 of ss);
+    label.bot("$g(x)=\frac12 \sin(3x)$", point 295 of tt); 
     label.urt("$f(x) + g(x)$", point 350 of uu);
     
     drawarrow xx; label.rt("$x$", point 1 of xx);


### PR DESCRIPTION
Change `sin` to `\sin` so **sin** is displayed in upright font, not italic.